### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@
 ^app.R$
 ^CODE_OF_CONDUCT\.md$
 ^rsconnect$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/functions.R
+++ b/R/functions.R
@@ -112,8 +112,11 @@ is_try_error <- function(x) {
 
 # Check Functions ----
 
-check_modal <- function(check, ns,
-                        title = "Please fix the following issue ...") {
+check_modal <- function(
+  check,
+  ns,
+  title = "Please fix the following issue ..."
+) {
   msg <- gsub("^Error (.*?)( : )", "", check[1])
   msg <- gsub("Error : ", "", msg)
   modalDialog(

--- a/R/mod-about.R
+++ b/R/mod-about.R
@@ -24,7 +24,6 @@ mod_about_ui <- function(id, label = "about") {
 }
 
 
-
 mod_about_server <- function(id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
@@ -38,7 +37,8 @@ mod_about_server <- function(id) {
     output$text_1 <- renderText({
       paste0(
         "bisonpictools version: ",
-        as.character(utils::packageVersion("bisonpictools")), "<br/>",
+        as.character(utils::packageVersion("bisonpictools")),
+        "<br/>",
         "shinybisonpic version: ",
         as.character(utils::packageVersion("shinybisonpic"))
       )

--- a/R/mod-help.R
+++ b/R/mod-help.R
@@ -23,7 +23,6 @@ mod_help_ui <- function(id, label = "help") {
 }
 
 
-
 mod_help_server <- function(id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns

--- a/R/mod-plot.R
+++ b/R/mod-plot.R
@@ -58,7 +58,8 @@ mod_plot_ui <- function(id, label = "plot") {
     width = 12,
     title = "Plots",
     uiOutput(ns("download_button")),
-    br(), br(),
+    br(),
+    br(),
     uiOutput(ns("ui_plot"))
   )
 
@@ -110,8 +111,12 @@ mod_plot_server <- function(id, upload) {
         ns("select_numerator_m"),
         label = NULL,
         choices = c(
-          "male calf", "male yearling", "male adult", "male unknown",
-          "male 2 yr old", "male 3 yr old"
+          "male calf",
+          "male yearling",
+          "male adult",
+          "male unknown",
+          "male 2 yr old",
+          "male 3 yr old"
         )
       )
     })
@@ -121,7 +126,10 @@ mod_plot_server <- function(id, upload) {
         ns("select_numerator_f"),
         label = NULL,
         choices = c(
-          "female calf", "female yearling", "female adult", "female unknown"
+          "female calf",
+          "female yearling",
+          "female adult",
+          "female unknown"
         )
       )
     })
@@ -131,7 +139,10 @@ mod_plot_server <- function(id, upload) {
         ns("select_numerator_u"),
         label = NULL,
         choices = c(
-          "unknown calf", "unknown yearling", "unknown adult", "unknown unknown"
+          "unknown calf",
+          "unknown yearling",
+          "unknown adult",
+          "unknown unknown"
         )
       )
     })
@@ -155,8 +166,12 @@ mod_plot_server <- function(id, upload) {
         ns("select_denominator_m"),
         label = NULL,
         choices = c(
-          "male calf", "male yearling", "male adult", "male unknown",
-          "male 2 yr old", "male 3 yr old"
+          "male calf",
+          "male yearling",
+          "male adult",
+          "male unknown",
+          "male 2 yr old",
+          "male 3 yr old"
         )
       )
     })
@@ -166,7 +181,10 @@ mod_plot_server <- function(id, upload) {
         ns("select_denominator_f"),
         label = NULL,
         choices = c(
-          "female calf", "female yearling", "female adult", "female unknown"
+          "female calf",
+          "female yearling",
+          "female adult",
+          "female unknown"
         )
       )
     })
@@ -176,7 +194,10 @@ mod_plot_server <- function(id, upload) {
         ns("select_denominator_u"),
         label = NULL,
         choices = c(
-          "unknown calf", "unknown yearling", "unknown adult", "unknown unknown"
+          "unknown calf",
+          "unknown yearling",
+          "unknown adult",
+          "unknown unknown"
         )
       )
     })
@@ -256,8 +277,11 @@ mod_plot_server <- function(id, upload) {
           "'",
           "",
           paste0(
-            "Numerator: ", chk::cc(rv$numerator, ellipsis = 20L), "\n",
-            "Denominator: ", chk::cc(rv$denominator, ellipsis = 20L)
+            "Numerator: ",
+            chk::cc(rv$numerator, ellipsis = 20L),
+            "\n",
+            "Denominator: ",
+            chk::cc(rv$denominator, ellipsis = 20L)
           )
         )
 

--- a/R/mod-upload.R
+++ b/R/mod-upload.R
@@ -23,13 +23,19 @@ mod_upload_ui <- function(id, label = "upload") {
       size = "l"
     ),
     br(),
-    tags$label("1. Download and fill in template"), br(),
+    tags$label("1. Download and fill in template"),
+    br(),
     downloadButton(ns("download_template"), "Template"),
-    br(), br(),
+    br(),
+    br(),
     tags$label("2. Upload data"),
     uiOutput(ns("upload_bison")),
-    br(), br(), br(), br(),
-    tags$label("Download example data set"), br(),
+    br(),
+    br(),
+    br(),
+    br(),
+    tags$label("Download example data set"),
+    br(),
     downloadButton(ns("download_example"), "Example Data")
   )
 
@@ -70,7 +76,6 @@ mod_upload_server <- function(id) {
 
       rv$template_dl <- template_dl
     })
-
 
     output$download_template <- downloadHandler(
       filename = "template-bison.xlsx",
@@ -160,7 +165,8 @@ mod_upload_server <- function(id) {
     })
 
     # create and display uploaded data
-    observeEvent(input$upload,
+    observeEvent(
+      input$upload,
       {
         sheets_data <- readxl::excel_sheets(input$upload$datapath)
         try_sheet_names <- try(

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true


### PR DESCRIPTION
Closes #59

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)